### PR TITLE
Translate the issue type dropdown values

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -136,10 +136,6 @@ export default {
     repo: '',
     repos,
     type: 'bug-report',
-    types: [
-      { id: 'bug-report', name: 'Bug Report' },
-      { id: 'feature-request', name: 'Feature Request' }
-    ],
     versions: {}
   }),
 
@@ -162,6 +158,15 @@ export default {
       const label = this.type === 'feature-request' ? '&labels=feature%20request' : ''
       window.open(`https://github.com/${this.repo}/issues/new?title=${title}&body=${body}${label}`)
     },
+  },
+
+  computed: {
+    types () {
+      return this.$lang && [
+        { id: 'bug-report', name: this.i18n('bug-report') },
+        { id: 'feature-request', name: this.i18n('feature-request') }
+      ]
+    }
   },
 
   created () {

--- a/src/i18n/locales/en/index.js
+++ b/src/i18n/locales/en/index.js
@@ -39,4 +39,8 @@ module.exports = {
   'preview': 'Preview',
   'preview-title': 'Issue Preview',
   'create': 'Create',
+
+  // misc
+  'bug-report': 'Bug Report',
+  'feature-request': 'Feature Request',
 }

--- a/src/i18n/locales/zh-cn/index.js
+++ b/src/i18n/locales/zh-cn/index.js
@@ -39,4 +39,8 @@ module.exports = {
   'preview': '预览',
   'preview-title': '预览',
   'create': '创建 Issue',
+
+  // misc
+  'bug-report': '错误报告',
+  'feature-request': '功能要求',
 }


### PR DESCRIPTION
This PR attempts to translate the issue type dropdown values ("Bug Report"/"Feature Request") by turning the `types` into a computed property and make `lang` a reactive dependency. This might feel a bit hacky to some, though, so ideas are welcome.