### PR TITLE
"Stack Overflow" instead of "StackOverflow"

### DIFF
--- a/src/i18n/locales/en/intro.md
+++ b/src/i18n/locales/en/intro.md
@@ -7,6 +7,6 @@ For usage questions, please use the following resources:
 - Read the [docs](https://vuejs.org/guide/)
 - Watch [video tutorials](https://laracasts.com/series/learn-vue-2-step-by-step)
 - Ask on the [forums](https://forum.vuejs.org/)
-- Look for / ask questions on [StackOverflow](https://stackoverflow.com/questions/ask?tags=vue.js)
+- Look for / ask questions on [Stack Overflow](https://stackoverflow.com/questions/ask?tags=vue.js)
 
 Also try to search for your issue - it may have already been answered or even fixed in the development branch. However, if you find that an old, closed issue still persists in the latest version, you should open a new issue using the form below instead of commenting on the old issue.

--- a/src/i18n/locales/zh-cn/intro.md
+++ b/src/i18n/locales/zh-cn/intro.md
@@ -9,7 +9,7 @@
 - 仔细阅读 [文档](https://cn.vuejs.org/v2/guide/)
 - 观看 [视频教程](https://laracasts.com/series/learn-vue-2-step-by-step) (英文)
 - 到 [官方论坛](https://forum.vuejs.org/) 提问（英文）
-- 在 [StackOverflow](https://stackoverflow.com/questions/ask?tags=vue.js) (英文) 或是 [SegmentFault](https://segmentfault.com/t/vue.js)（中文）搜索和提问
+- 在 [Stack Overflow](https://stackoverflow.com/questions/ask?tags=vue.js) (英文) 或是 [SegmentFault](https://segmentfault.com/t/vue.js)（中文）搜索和提问
 - 到 [中文社区](http://www.vue-js.com/) 提问（非官方）
 
 最后，在开 issue 前，可以先搜索以下以往的旧 issue - 你遇到的问题可能已经有人提了，也可能已经在最新版本中被修正。注意：如果你发现一个已经关闭的旧 issue 在最新版本中仍然存在，请不要在旧 issue 下面留言，而应该用下面的表单开一个新的 issue。


### PR DESCRIPTION
Hi,

The official name should be "Stack Overflow" according to their website.