### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/BugReport.vue
+++ b/src/components/BugReport.vue
@@ -241,7 +241,7 @@ export default {
 
       this.versions = this.versions.concat(
         releases.map(r => ({
-          value: /^v/.test(r.tag_name) ? r.tag_name.substr(1) : r.tag_name
+          value: /^v/.test(r.tag_name) ? r.tag_name.slice(1) : r.tag_name
         }))
       )
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.